### PR TITLE
defend the faucet

### DIFF
--- a/src/actions/turnkey.ts
+++ b/src/actions/turnkey.ts
@@ -319,7 +319,7 @@ export const fundWallet = async (address: Address, value: bigint) => {
   const balance = await getBalance(address)
 
   if (receivedTransactions.length > 5 || balance > value * 2n) {
-    throw new Error("you have used your alotted number of faucet drips")
+    return ""
   }
 
   const walletClient = await getTurnkeyWalletClient(

--- a/src/actions/turnkey.ts
+++ b/src/actions/turnkey.ts
@@ -14,6 +14,8 @@ import { siteConfig } from "@/config/site"
 import { turnkeyConfig } from "@/config/turnkey"
 import { getTurnkeyWalletClient } from "@/lib/web3"
 
+import { getBalance, getTransactions } from "./web3"
+
 const {
   TURNKEY_API_PUBLIC_KEY,
   TURNKEY_API_PRIVATE_KEY,
@@ -313,6 +315,13 @@ const warchestClient = new TurnkeyServerClient({
 })
 
 export const fundWallet = async (address: Address, value: bigint) => {
+  const { receivedTransactions } = await getTransactions(address)
+  const balance = await getBalance(address)
+
+  if (receivedTransactions.length > 5 || balance > value * 2n) {
+    throw new Error("you have used your alotted number of faucet drips")
+  }
+
   const walletClient = await getTurnkeyWalletClient(
     warchestClient,
     WARCHEST_PRIVATE_KEY_ID
@@ -322,5 +331,6 @@ export const fundWallet = async (address: Address, value: bigint) => {
     to: address,
     value,
   })
+
   return txHash
 }

--- a/src/actions/web3.ts
+++ b/src/actions/web3.ts
@@ -1,9 +1,10 @@
 "use server"
 
-import { Alchemy, Network } from "alchemy-sdk"
-import { Address } from "viem"
+import { Alchemy, AssetTransfersCategory, Network } from "alchemy-sdk"
+import { Address, getAddress, parseEther } from "viem"
 
 import { env } from "@/env.mjs"
+import type { Transaction } from "@/types/web3"
 
 const settings = {
   apiKey: env.NEXT_PUBLIC_ALCHEMY_API_KEY,
@@ -12,15 +13,80 @@ const settings = {
 
 const alchemy = new Alchemy(settings)
 
+export const getBalance = async (address: Address) => {
+  let response = await alchemy.core.getBalance(address, "latest")
+  const balanceBigInt = BigInt(response.toString())
+  return balanceBigInt
+}
+
 export const getTokenBalance = async (address: Address) => {
   const tokenBalances = await alchemy.core.getTokenBalances(address)
   return tokenBalances
 }
 
-export const getBalance = async (address: Address) => {
-  let response = await alchemy.core.getBalance(address, "latest")
-  const balanceBigInt = BigInt(response.toString())
-  return balanceBigInt
+export const getTransactions = async (
+  address: Address
+): Promise<Record<string, Transaction[]>> => {
+  // Fetch sent and received transactions concurrently
+  const [sentResponse, receivedResponse] = await Promise.all([
+    alchemy.core.getAssetTransfers({
+      fromAddress: address,
+      excludeZeroValue: false,
+      category: [
+        AssetTransfersCategory.ERC20,
+        AssetTransfersCategory.EXTERNAL,
+        AssetTransfersCategory.INTERNAL,
+      ],
+      withMetadata: true,
+    }),
+    alchemy.core.getAssetTransfers({
+      toAddress: address,
+      excludeZeroValue: false,
+      category: [
+        AssetTransfersCategory.ERC20,
+        AssetTransfersCategory.EXTERNAL,
+        AssetTransfersCategory.INTERNAL,
+      ],
+      withMetadata: true,
+    }),
+  ])
+
+  // Map the responses
+  const sentTransactions = [
+    ...sentResponse.transfers.map(
+      ({ blockNum, from, to, hash, value, metadata }) => ({
+        blockNumber: Number(blockNum),
+        from: getAddress(from),
+        to: to ? getAddress(to) : null,
+        hash,
+        value: value ? parseEther(value.toString()) : null,
+        status: "sent" as const,
+        timestamp: metadata.blockTimestamp,
+      })
+    ),
+  ]
+  const receivedTransactions = [
+    ...receivedResponse.transfers.map(
+      ({ blockNum, from, to, hash, value, metadata }) => ({
+        blockNumber: Number(blockNum),
+        from: getAddress(from),
+        to: to ? getAddress(to) : null,
+        hash,
+        value: value ? parseEther(value.toString()) : null,
+        status: "received" as const,
+        timestamp: metadata.blockTimestamp,
+      })
+    ),
+  ]
+
+  // Sort transactions by block number in descending order
+  sentTransactions.sort((a, b) => b.blockNumber - a.blockNumber)
+  receivedTransactions.sort((a, b) => b.blockNumber - a.blockNumber)
+
+  return {
+    sentTransactions,
+    receivedTransactions,
+  }
 }
 
 type TokenPriceResponse<T extends string> = {

--- a/src/actions/web3.ts
+++ b/src/actions/web3.ts
@@ -9,6 +9,10 @@ import type { Transaction } from "@/types/web3"
 const settings = {
   apiKey: env.NEXT_PUBLIC_ALCHEMY_API_KEY,
   network: Network.ETH_SEPOLIA,
+  // https://github.com/alchemyplatform/alchemy-sdk-js/issues/400
+  connectionInfoOverrides: {
+    skipFetchSetup: true,
+  },
 }
 
 const alchemy = new Alchemy(settings)

--- a/src/config/site.ts
+++ b/src/config/site.ts
@@ -1,8 +1,9 @@
 import { SiteConfig } from "@/types"
 
-const baseUrl = process.env.NEXT_PUBLIC_VERCEL_PROJECT_PRODUCTION_URL
-  ? `https://${process.env.NEXT_PUBLIC_VERCEL_PROJECT_PRODUCTION_URL}`
-  : `https://${process.env.NEXT_PUBLIC_VERCEL_BRANCH_URL}`
+const baseUrl =
+  process.env.NEXT_PUBLIC_VERCEL_ENV === "production"
+    ? `https://${process.env.NEXT_PUBLIC_VERCEL_PROJECT_PRODUCTION_URL}`
+    : `https://${process.env.NEXT_PUBLIC_VERCEL_BRANCH_URL}`
 
 export const siteConfig: SiteConfig = {
   name: "Demo Embedded Wallet",

--- a/src/lib/web3.ts
+++ b/src/lib/web3.ts
@@ -129,6 +129,10 @@ export const fundWallet = async (address: Address) => {
     const publicClient = getPublicClient()
     const hash = await serverFundWallet(address, parseEther(amount))
 
+    if (hash === "") {
+      throw new Error("unable to drip from faucet. You may be dripped out 💧")
+    }
+
     const toastId = showTransactionToast({
       hash,
       title: "Funding wallet...",

--- a/src/lib/web3.ts
+++ b/src/lib/web3.ts
@@ -98,9 +98,6 @@ const getWebSocketClient = () => {
     webSocketClient = createPublicClient({
       chain: sepolia,
       transport: webSocket("wss://ethereum-sepolia-rpc.publicnode.com"),
-      // transport: webSocket(
-      //   "wss://eth-sepolia.g.alchemy.com/v2/erQ2WeonfN1VMZQM_PgCMTQB4USjPXoD"
-      // ),
     })
   }
   return webSocketClient
@@ -127,7 +124,7 @@ export const watchPendingTransactions = (
 }
 
 export const fundWallet = async (address: Address) => {
-  const amount = "0.02" // ETH
+  const amount = "0.01" // ETH
   try {
     const publicClient = getPublicClient()
     const hash = await serverFundWallet(address, parseEther(amount))

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "target": "es2020",
+    "lib": ["dom", "dom.iterable", "esnext", "es2020"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,


### PR DESCRIPTION
- reduce drip to 0.01 ETH
- limit drip if > 5 txs have been received, or balance > 2 * 0.01 ETH. this is currently all being done on the server side
  - server actions vs web actions could use some DRY
