### PR TITLE
Add loginWithReadWriteSession for oauth

### DIFF
--- a/src/actions/turnkey.ts
+++ b/src/actions/turnkey.ts
@@ -177,38 +177,6 @@ export const initEmailAuth = async ({
   }
 }
 
-export const initEmailRecovery = async ({
-  email,
-  targetPublicKey,
-}: {
-  email: Email
-  targetPublicKey: string
-}) => {
-  let organizationId = await getSubOrgIdByEmail(email as Email)
-
-  if (!organizationId) {
-    const { subOrg } = await createUserSubOrg({
-      email: email as Email,
-    })
-    organizationId = subOrg.subOrganizationId
-  }
-
-  const magicLinkTemplate = getMagicLinkTemplate("auth", email, "email")
-
-  if (organizationId?.length) {
-    const authResponse = await client.emailAuth({
-      email,
-      targetPublicKey,
-      organizationId,
-      emailCustomization: {
-        magicLinkTemplate,
-      },
-    })
-
-    return authResponse
-  }
-}
-
 type EmailParam = { email: Email }
 type PublicKeyParam = { publicKey: string }
 type UsernameParam = { username: string }

--- a/src/actions/turnkey.ts
+++ b/src/actions/turnkey.ts
@@ -9,7 +9,12 @@ import { decode, JwtPayload } from "jsonwebtoken"
 import { Address, getAddress, parseEther } from "viem"
 
 import { env } from "@/env.mjs"
-import { Attestation, Email, Wallet } from "@/types/turnkey"
+import {
+  Attestation,
+  Email,
+  OauthProviderParams,
+  Wallet,
+} from "@/types/turnkey"
 import { siteConfig } from "@/config/site"
 import { turnkeyConfig } from "@/config/turnkey"
 import { getTurnkeyWalletClient } from "@/lib/web3"
@@ -56,9 +61,7 @@ export const createUserSubOrg = async ({
     challenge: string
     attestation: Attestation
   }
-  oauth?: {
-    credential: string
-  }
+  oauth?: OauthProviderParams
 }) => {
   const authenticators = passkey
     ? [
@@ -73,8 +76,8 @@ export const createUserSubOrg = async ({
   const oauthProviders = oauth
     ? [
         {
-          providerName: "Google Auth - Embedded Wallet",
-          oidcToken: oauth.credential,
+          providerName: oauth.providerName,
+          oidcToken: oauth.oidcToken,
         },
       ]
     : []
@@ -83,7 +86,7 @@ export const createUserSubOrg = async ({
   // If the user is logging in with a Google Auth credential, use the email from the decoded OIDC token (credential
   // Otherwise, use the email from the email parameter
   if (oauth) {
-    const decoded = decodeJwt(oauth.credential)
+    const decoded = decodeJwt(oauth.oidcToken)
     if (decoded?.email) {
       userEmail = decoded.email
     }
@@ -143,6 +146,38 @@ const getMagicLinkTemplate = (action: string, email: string, method: string) =>
   `${siteConfig.url.base}/email-${action}?userEmail=${email}&continueWith=${method}&credentialBundle=%s`
 
 export const initEmailAuth = async ({
+  email,
+  targetPublicKey,
+}: {
+  email: Email
+  targetPublicKey: string
+}) => {
+  let organizationId = await getSubOrgIdByEmail(email as Email)
+
+  if (!organizationId) {
+    const { subOrg } = await createUserSubOrg({
+      email: email as Email,
+    })
+    organizationId = subOrg.subOrganizationId
+  }
+
+  const magicLinkTemplate = getMagicLinkTemplate("auth", email, "email")
+
+  if (organizationId?.length) {
+    const authResponse = await client.emailAuth({
+      email,
+      targetPublicKey,
+      organizationId,
+      emailCustomization: {
+        magicLinkTemplate,
+      },
+    })
+
+    return authResponse
+  }
+}
+
+export const initEmailRecovery = async ({
   email,
   targetPublicKey,
 }: {

--- a/src/components/add-passkey.tsx
+++ b/src/components/add-passkey.tsx
@@ -19,7 +19,7 @@ export default function AddPasskey({
 }: {
   onPasskeyAdded: (authenticatorId: string) => void
 }) {
-  const { passkeyClient, turnkey, getActiveClient } = useTurnkey()
+  const { passkeyClient, getActiveClient } = useTurnkey()
   const { user } = useUser()
   const [open, setOpen] = useState(false)
   const [passkeyName, setPasskeyName] = useState("")

--- a/src/components/add-passkey.tsx
+++ b/src/components/add-passkey.tsx
@@ -19,7 +19,7 @@ export default function AddPasskey({
 }: {
   onPasskeyAdded: (authenticatorId: string) => void
 }) {
-  const { passkeyClient, getActiveClient } = useTurnkey()
+  const { passkeyClient, turnkey, getActiveClient } = useTurnkey()
   const { user } = useUser()
   const [open, setOpen] = useState(false)
   const [passkeyName, setPasskeyName] = useState("")

--- a/src/components/auth.tsx
+++ b/src/components/auth.tsx
@@ -143,20 +143,7 @@ export default function Auth() {
               </span>
             </div>
           </div>
-          <GoogleAuth loading={state.loading && loadingAction === "email"} />
-          {/* <div className="relative">
-            <div className="absolute inset-0 flex items-center">
-              <Separator className="w-full" />
-            </div>
-            <div className="relative flex justify-center text-xs uppercase">
-              <span className="bg-background px-2 text-muted-foreground">
-                Or
-              </span>
-            </div>
-          </div>
-          <Button disabled variant="outline" className="w-full font-semibold">
-            Continue with Wallet
-          </Button> */}
+          <GoogleAuth />
         </CardContent>
       </Card>
       <Legal />

--- a/src/components/google-auth.tsx
+++ b/src/components/google-auth.tsx
@@ -14,13 +14,12 @@ import { env } from "@/env.mjs"
 
 import { Skeleton } from "./ui/skeleton"
 
-// @todo: these will be used once we can create a custom google login button
-const GoogleAuth = ({ loading }: { loading: boolean }) => {
+const GoogleAuth = () => {
   const { authIframeClient } = useTurnkey()
   const clientId = env.NEXT_PUBLIC_GOOGLE_OAUTH_CLIENT_ID
 
   const [nonce, setNonce] = useState("")
-  const { loginWithOAuth } = useAuth()
+  const { loginWithGoogle } = useAuth()
 
   useEffect(() => {
     if (authIframeClient?.iframePublicKey) {
@@ -34,7 +33,7 @@ const GoogleAuth = ({ loading }: { loading: boolean }) => {
 
   const onSuccess = (credentialResponse: CredentialResponse) => {
     if (credentialResponse.credential) {
-      loginWithOAuth(credentialResponse.credential as string)
+      loginWithGoogle(credentialResponse.credential as string)
     }
   }
 

--- a/src/providers/auth-provider.tsx
+++ b/src/providers/auth-provider.tsx
@@ -95,7 +95,9 @@ const AuthContext = createContext<{
     credentialBundle: string
   }) => Promise<void>
   loginWithPasskey: (email?: Email) => Promise<void>
-  loginWithOAuth: (credential: string) => Promise<void>
+  loginWithOAuth: (credential: string, providerName: string) => Promise<void>
+  loginWithGoogle: (credential: string) => Promise<void>
+  loginWithApple: (credential: string) => Promise<void>
   logout: () => Promise<void>
 }>({
   state: initialState,
@@ -103,6 +105,8 @@ const AuthContext = createContext<{
   completeEmailAuth: async () => {},
   loginWithPasskey: async () => {},
   loginWithOAuth: async () => {},
+  loginWithGoogle: async () => {},
+  loginWithApple: async () => {},
   logout: async () => {},
 })
 
@@ -235,7 +239,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     }
   }
 
-  const loginWithOAuth = async (credential: string) => {
+  const loginWithOAuth = async (credential: string, providerName: string) => {
     dispatch({ type: "LOADING", payload: true })
     try {
       // Determine if the user has a sub-organization associated with their email
@@ -246,7 +250,8 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
         // Create a new sub-organization for the user
         const { subOrg } = await createUserSubOrg({
           oauth: {
-            credential,
+            oidcToken: credential,
+            providerName,
           },
         })
         subOrgId = subOrg.subOrganizationId
@@ -288,6 +293,14 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     }
   }
 
+  const loginWithGoogle = async (credential: string) => {
+    await loginWithOAuth(credential, "Google Auth - Embedded Wallet")
+  }
+
+  const loginWithApple = async (credential: string) => {
+    await loginWithOAuth(credential, "Apple Auth - Embedded Wallet")
+  }
+
   const logout = async () => {
     await turnkey?.logoutUser()
     googleLogout()
@@ -302,6 +315,8 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
         completeEmailAuth,
         loginWithPasskey,
         loginWithOAuth,
+        loginWithGoogle,
+        loginWithApple,
         logout,
       }}
     >

--- a/src/providers/auth-provider.tsx
+++ b/src/providers/auth-provider.tsx
@@ -252,30 +252,33 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
         subOrgId = subOrg.subOrganizationId
       }
 
-      const oauthResponse = await oauth({
-        credential,
-        targetPublicKey: `${authIframeClient?.iframePublicKey}`,
-        targetSubOrgId: subOrgId,
-      })
-      await authIframeClient?.injectCredentialBundle(
-        oauthResponse.credentialBundle
-      )
       if (authIframeClient?.iframePublicKey) {
-        const loginResponse = await authIframeClient?.loginWithReadWriteSession(
-          authIframeClient.iframePublicKey
+        const oauthResponse = await oauth({
+          credential,
+          targetPublicKey: authIframeClient?.iframePublicKey,
+          targetSubOrgId: subOrgId,
+        })
+        const injectSuccess = await authIframeClient?.injectCredentialBundle(
+          oauthResponse.credentialBundle
         )
-        if (loginResponse?.organizationId) {
-          // Save the user in localStorage
-          await setStorageValue(
-            StorageKeys.CurrentUser,
-            loginResponseToUser(loginResponse)
-          )
+        if (injectSuccess) {
+          const loginResponse =
+            await authIframeClient?.loginWithReadWriteSession(
+              authIframeClient.iframePublicKey
+            )
+          if (loginResponse?.organizationId) {
+            // Save the user in localStorage
+            await setStorageValue(
+              StorageKeys.CurrentUser,
+              loginResponseToUser(loginResponse)
+            )
 
-          dispatch({
-            type: "OAUTH",
-            payload: loginResponseToUser(loginResponse),
-          })
-          router.push("/dashboard")
+            dispatch({
+              type: "OAUTH",
+              payload: loginResponseToUser(loginResponse),
+            })
+            router.push("/dashboard")
+          }
         }
       }
     } catch (error: any) {

--- a/src/types/turnkey.ts
+++ b/src/types/turnkey.ts
@@ -35,3 +35,5 @@ export interface ReadOnlySession {
   session: string
   sessionExpiry: number
 }
+
+export type OauthProviderParams = TurnkeyApiTypes["v1OauthProviderParams"]


### PR DESCRIPTION
There's a bug with oauth such that the read/write session doesn't get stored which will make users who login with oauth use their potentially non-existing passkey for authenticated requests rather than using the read/write session from the oauth response