### PR TITLE
hard refresh on passkey cancel

### DIFF
--- a/src/providers/auth-provider.tsx
+++ b/src/providers/auth-provider.tsx
@@ -316,6 +316,12 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
         }
       }
     } catch (error: any) {
+      // Catch the user cancel error and force a hard reload to avoid a stalled key
+      const message: string = error?.message || "";
+      if (message.includes("NotAllowedError")) {
+      window.location.reload();
+      return;
+    }
       dispatch({ type: "ERROR", payload: error.message })
     } finally {
       dispatch({ type: "LOADING", payload: false })


### PR DESCRIPTION
when the user cancel the passkey login flow we end up with a new indexedDb key but the oauth nonce has already been calculated at the inital mount
adding a force reload to allow a nonce refresh