### PR TITLE
improve value-input sanitization; remove add funds

### DIFF
--- a/src/components/wallet-card.tsx
+++ b/src/components/wallet-card.tsx
@@ -3,12 +3,11 @@
 import { useEffect, useState } from "react"
 import { useWallets } from "@/providers/wallet-provider"
 import { ExportType, useTurnkey } from "@turnkey/react-wallet-kit"
-import { CopyIcon, Download, HandCoins, Upload } from "lucide-react"
+import { CopyIcon, Download, Upload } from "lucide-react"
 import { toast } from "sonner"
 import { formatEther } from "viem"
 
 import { truncateAddress } from "@/lib/utils"
-import { fundWallet } from "@/lib/web3"
 import { useTokenPrice } from "@/hooks/use-token-price"
 import { Button } from "@/components/ui/button"
 import {
@@ -28,11 +27,6 @@ export default function WalletCard() {
   const { handleImport, handleExport } = useTurnkey()
   const { selectedWallet, selectedAccount } = state
   const [usdAmount, setUsdAmount] = useState<number | undefined>(undefined)
-
-  const handleFundWallet = async () => {
-    if (!selectedAccount?.address) return
-    await fundWallet(selectedAccount?.address)
-  }
 
   const handleCopyAddress = () => {
     if (selectedAccount?.address) {
@@ -58,10 +52,6 @@ export default function WalletCard() {
         </CardTitle>
 
         <div className="hidden items-center gap-2 sm:flex">
-          <Button onClick={handleFundWallet} className="h-min cursor-pointer">
-            <HandCoins className="mr-2 h-4 w-4" />
-            Add funds
-          </Button>
           <TransferDialog />
 
           <Button variant="outline" onClick={() => handleImport()}>
@@ -111,10 +101,6 @@ export default function WalletCard() {
       </CardContent>
       <CardFooter className="sm:hidden">
         <div className="mx-auto flex w-full flex-col items-center gap-2">
-          <Button className="w-full">
-            <HandCoins className="mr-2 h-4 w-4" />
-            Add funds
-          </Button>
           <TransferDialog />
           <div className="flex w-full items-center gap-2">
             <Button

--- a/src/config/turnkey.ts
+++ b/src/config/turnkey.ts
@@ -28,7 +28,6 @@ export const customWallet = {
 export const turnkeyConfig: TurnkeyProviderConfig = {
   organizationId: NEXT_PUBLIC_ORGANIZATION_ID,
   authProxyConfigId: NEXT_PUBLIC_AUTH_PROXY_ID,
-  authProxyUrl: NEXT_PUBLIC_AUTH_PROXY_URL,
   apiBaseUrl: NEXT_PUBLIC_BASE_URL,
   auth: {
     autoRefreshSession: true,


### PR DESCRIPTION
### Improve ValueInput: strict decimal sanitizer, UX tweaks, and blur coercion

- **What**: Ensures only valid decimal values can be entered while keeping smooth typing UX.
- **How**:
  - Added a small sanitizer used on change:
    - Strict dot-only (commas removed)
    - Single decimal point (extra dots dropped)
    - Leading-zero normalization (`.5` → `0.5`, `00012` → `12`, `00.5` → `0.5`)
    - Caps fractional part at **10** decimals
  - Allowed `1.` as a typing state; on blur it becomes `1` (also `.` → `0`).
  - Removed unnecessary event suppression in `onChange`.
  - Input UX: `inputMode="decimal"`, `autoComplete="off"`, `spellCheck={false}`, added `aria-label`.
  - Minor className ordering tidy-ups.

- **Before**: Allowed `...`, `0....`, `1..2`, `0.0.0.` and other invalid strings.
- **After**: Those inputs are sanitized to valid forms (e.g., `1..2` → `1.2`, `...` → `0.` while typing, `0` on blur).

No visual layout changes; scaling/width logic unchanged.