### PR TITLE
fix wallet loading

### DIFF
--- a/src/providers/wallet-provider.tsx
+++ b/src/providers/wallet-provider.tsx
@@ -287,11 +287,23 @@ export function WalletsProvider({ children }: { children: ReactNode }) {
   }
 
   const selectAccount = async (account: Account) => {
-    const balance = await getCachedBalance(account.address)
+    // Set account immediately to avoid UI blocking
     dispatch({
       type: "SET_SELECTED_ACCOUNT",
-      payload: { ...account, balance },
+      payload: { ...account, balance: 0n },
     })
+
+    // Fetch balance in background and update when ready
+    try {
+      const balance = await getCachedBalance(account.address)
+      dispatch({
+        type: "SET_SELECTED_ACCOUNT",
+        payload: { ...account, balance },
+      })
+    } catch (error) {
+      console.error("Error fetching balance:", error)
+      // Keep the account selected with 0 balance on error
+    }
   }
 
   const value = {


### PR DESCRIPTION
```
The loading appeared stuck for fresh wallets due to three issues:

Initial loading state: started with loading: true, so the UI showed loading even before any data was being fetched

No timeout on API calls: If Alchemy API calls were slow for fresh addresses, the loading state would hang indefinitely

Blocking account selection:  waited for the balance to be fetched before setting the selected account, which blocked the entire UI flow
```