### PR TITLE
Handle wallets with no accounts in dropdown and wallet card

### DIFF
--- a/src/components/account.tsx
+++ b/src/components/account.tsx
@@ -101,7 +101,7 @@ export default function Account() {
         >
           <div className="flex items-center gap-3">
             <AccountAvatar address={selectedAccount?.address} />
-            {selectedWallet?.walletName && selectedAccount?.address ? (
+            {selectedWallet?.walletName ? (
               <div className="text-left">
                 <div className="text-sm font-semibold">
                   {selectedWallet?.walletName}
@@ -109,7 +109,7 @@ export default function Account() {
                 <div className="text-muted-foreground text-xs font-semibold">
                   {selectedAccount?.address
                     ? truncateAddress(selectedAccount?.address)
-                    : ""}
+                    : "No accounts. Please create one via nav bar panel."}
                 </div>
               </div>
             ) : (

--- a/src/components/wallet-card.tsx
+++ b/src/components/wallet-card.tsx
@@ -91,6 +91,10 @@ export default function WalletCard() {
               {truncateAddress(selectedAccount?.address)}
               <CopyIcon className="h-3 w-3" />
             </div>
+          ) : selectedWallet?.walletName ? (
+            <span className="text-muted-foreground">
+              No accounts. Please create one via nav bar panel.
+            </span>
           ) : (
             <Skeleton className="bg-muted-foreground/50 h-3 w-32 rounded-sm" />
           )}


### PR DESCRIPTION
Imported wallets may not have associated accounts. Previously, the UI showed skeleton loaders indefinitely when a wallet had no account address. Now it displays the wallet name with 'No accounts' instead and adds a tip on how to create a new account for an imported wallet.